### PR TITLE
Assignment 48 queue using double stack

### DIFF
--- a/queueUsingStack.c
+++ b/queueUsingStack.c
@@ -1,15 +1,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define SIZE 100
+
 struct Stack
 {
-    int data[100];
+    int data[SIZE];
     int top, size;
 };
 
+struct Stack *init()
+{
+    struct Stack *stack = (struct Stack *)malloc(sizeof(struct Stack));
+    stack->top = -1;
+    stack->size = 0;
+    return stack;
+}
+
 void push(struct Stack *stack, int value)
 {
-    if (stack->size == 100)
+    if (stack->size == SIZE)
     {
         printf("Queue Overflow!\n");
         return;
@@ -69,7 +79,7 @@ int front(struct Stack *stack1, struct Stack *stack2)
     {
         while (stack1->size > 0)
         {
-            int value = pop(stack2);
+            int value = pop(stack1);
             push(stack2, value);
         }
     }
@@ -82,15 +92,15 @@ int isEmpty(struct Stack *stack1, struct Stack *stack2)
     return stack1->size == 0 && stack2->size == 0;
 }
 
+void freeStack(struct Stack *stack)
+{
+    free(stack);
+}
+
 int main()
 {
-    struct Stack *stack1 = (struct Stack *)malloc(sizeof(struct Stack));
-    struct Stack *stack2 = (struct Stack *)malloc(sizeof(struct Stack));
-
-    stack1->top = -1;
-    stack1->size = 0;
-    stack2->top = -1;
-    stack2->size = 0;
+    struct Stack *stack1 = init();
+    struct Stack *stack2 = init();
 
     int choice, data;
 
@@ -121,8 +131,8 @@ int main()
             printf(isEmpty(stack1, stack2) ? "Queue is Empty\n" : "Queue is Not Empty\n");
             break;
         case 5:
-            free(stack1);
-            free(stack2);
+            freeStack(stack1);
+            freeStack(stack2);
             printf("Exiting...\n");
             return 0;
         default:

--- a/queueUsingStack.c
+++ b/queueUsingStack.c
@@ -7,7 +7,7 @@ struct Stack
     int top, size;
 };
 
-void enqueue(struct Stack *stack, int value)
+void push(struct Stack *stack, int value)
 {
     if (stack->size == 100)
     {
@@ -18,81 +18,83 @@ void enqueue(struct Stack *stack, int value)
     stack->size++;
 }
 
-int dequeue(struct Stack *stack)
+int pop(struct Stack *stack)
 {
     if (stack->size == 0)
     {
         printf("Queue Underflow!\n");
         return -1;
     }
-
-    struct Stack *tempStack = (struct Stack *)malloc(sizeof(struct Stack));
-    tempStack->top = -1;
-    tempStack->size = 0;
-
-    while (stack->size > 1)
-    {
-        enqueue(tempStack, stack->data[stack->top--]);
-        stack->size--;
-    }
-
-    int dequeuedValue = stack->data[stack->top--];
     stack->size--;
-
-    while (tempStack->size > 0)
-    {
-        enqueue(stack, tempStack->data[tempStack->top--]);
-        tempStack->size--;
-    }
-
-    free(tempStack);
-    return dequeuedValue;
+    return stack->data[(stack->top)--];
 }
 
-int front(struct Stack *stack)
+void enqueue(struct Stack *stack1)
 {
-    if (stack->size == 0)
+    int value;
+    printf("Enter data: ");
+    scanf("%d", &value);
+    push(stack1, value);
+}
+
+int dequeue(struct Stack *stack1, struct Stack *stack2)
+{
+    if (stack1->size == 0 && stack2->size == 0)
+    {
+        printf("Queue Underflow!\n");
+        return -1;
+    }
+
+    if (stack2->size == 0)
+    {
+        while (stack1->size > 0)
+        {
+            int value = pop(stack1);
+            push(stack2, value);
+        }
+    }
+
+    return pop(stack2);
+}
+
+int front(struct Stack *stack1, struct Stack *stack2)
+{
+    if (stack1->size == 0 && stack2->size == 0)
     {
         printf("Queue is empty.\n");
         return -1;
     }
 
-    struct Stack *tempStack = (struct Stack *)malloc(sizeof(struct Stack));
-    tempStack->size = 0;
-    tempStack->top = -1;
-
-    while (stack->size > 0)
+    if (stack2->size == 0)
     {
-        enqueue(tempStack, stack->data[stack->top--]);
-        stack->size--;
+        while (stack1->size > 0)
+        {
+            int value = pop(stack2);
+            push(stack2, value);
+        }
     }
 
-    int frontElement = tempStack->data[tempStack->top];
-
-    while (tempStack->size > 0)
-    {
-        enqueue(stack, tempStack->data[tempStack->top--]);
-        tempStack->size--;
-    }
-
-    free(tempStack);
-    return frontElement;
+    return stack2->data[stack2->top];
 }
 
-int isEmpty(struct Stack *stack)
+int isEmpty(struct Stack *stack1, struct Stack *stack2)
 {
-    return stack->size == 0;
+    return stack1->size == 0 && stack2->size == 0;
 }
 
 int main()
 {
-    struct Stack *stack = (struct Stack *)malloc(sizeof(struct Stack));
-    stack->top = -1;
-    stack->size = 0;
+    struct Stack *stack1 = (struct Stack *)malloc(sizeof(struct Stack));
+    struct Stack *stack2 = (struct Stack *)malloc(sizeof(struct Stack));
+
+    stack1->top = -1;
+    stack1->size = 0;
+    stack2->top = -1;
+    stack2->size = 0;
 
     int choice, data;
 
-    printf("\nQueue Using One Stack (Iterative Dequeue)\n");
+    printf("\nQueue Using Two Stacks\n");
     printf("1. Enqueue\n2. Dequeue\n3. Display Front\n4. Check Empty\n5. Exit\n");
 
     while (1)
@@ -103,25 +105,24 @@ int main()
         switch (choice)
         {
         case 1:
-            printf("Enter data: ");
-            scanf("%d", &data);
-            enqueue(stack, data);
+            enqueue(stack1);
             break;
         case 2:
-            data = dequeue(stack);
+            data = dequeue(stack1, stack2);
             if (data != -1)
                 printf("Dequeued: %d\n", data);
             break;
         case 3:
-            data = front(stack);
+            data = front(stack1, stack2);
             if (data != -1)
                 printf("Front: %d\n", data);
             break;
         case 4:
-            printf(isEmpty(stack) ? "Queue is Empty\n" : "Queue is Not Empty\n");
+            printf(isEmpty(stack1, stack2) ? "Queue is Empty\n" : "Queue is Not Empty\n");
             break;
         case 5:
-            free(stack);
+            free(stack1);
+            free(stack2);
             printf("Exiting...\n");
             return 0;
         default:

--- a/queueUsingStack.c
+++ b/queueUsingStack.c
@@ -28,13 +28,14 @@ void push(struct Stack *stack, int value)
     stack->size++;
 }
 
-int pop(struct Stack *stack)
+int pop(struct Stack *stack, int *success)
 {
     if (stack->size == 0)
     {
-        printf("Queue Underflow!\n");
+        *success = 0;
         return -1;
     }
+    *success = 1;
     stack->size--;
     return stack->data[(stack->top)--];
 }
@@ -47,11 +48,12 @@ void enqueue(struct Stack *stack1)
     push(stack1, value);
 }
 
-int dequeue(struct Stack *stack1, struct Stack *stack2)
+int dequeue(struct Stack *stack1, struct Stack *stack2, int *success)
 {
     if (stack1->size == 0 && stack2->size == 0)
     {
         printf("Queue Underflow!\n");
+        *success = 0;
         return -1;
     }
 
@@ -59,19 +61,20 @@ int dequeue(struct Stack *stack1, struct Stack *stack2)
     {
         while (stack1->size > 0)
         {
-            int value = pop(stack1);
+            int value = pop(stack1, success);
             push(stack2, value);
         }
     }
 
-    return pop(stack2);
+    return pop(stack2, success);
 }
 
-int front(struct Stack *stack1, struct Stack *stack2)
+int front(struct Stack *stack1, struct Stack *stack2, int *success)
 {
     if (stack1->size == 0 && stack2->size == 0)
     {
         printf("Queue is empty.\n");
+        *success = 0;
         return -1;
     }
 
@@ -79,11 +82,12 @@ int front(struct Stack *stack1, struct Stack *stack2)
     {
         while (stack1->size > 0)
         {
-            int value = pop(stack1);
+            int value = pop(stack1, success);
             push(stack2, value);
         }
     }
 
+    *success = 1;
     return stack2->data[stack2->top];
 }
 
@@ -102,7 +106,7 @@ int main()
     struct Stack *stack1 = init();
     struct Stack *stack2 = init();
 
-    int choice, data;
+    int choice, data, success;
 
     printf("\nQueue Using Two Stacks\n");
     printf("1. Enqueue\n2. Dequeue\n3. Display Front\n4. Check Empty\n5. Exit\n");
@@ -118,13 +122,13 @@ int main()
             enqueue(stack1);
             break;
         case 2:
-            data = dequeue(stack1, stack2);
-            if (data != -1)
+            data = dequeue(stack1, stack2, &success);
+            if (success)
                 printf("Dequeued: %d\n", data);
             break;
         case 3:
-            data = front(stack1, stack2);
-            if (data != -1)
+            data = front(stack1, stack2, &success);
+            if (success)
                 printf("Front: %d\n", data);
             break;
         case 4:
@@ -134,10 +138,13 @@ int main()
             freeStack(stack1);
             freeStack(stack2);
             printf("Exiting...\n");
-            return 0;
+            break;
         default:
             printf("Invalid Choice!\n");
         }
+
+        if (choice == 5)
+            break;
     }
 
     return 0;

--- a/queueUsingStack.c
+++ b/queueUsingStack.c
@@ -1,0 +1,134 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+struct Stack
+{
+    int data[100];
+    int top, size;
+};
+
+void enqueue(struct Stack *stack, int value)
+{
+    if (stack->size == 100)
+    {
+        printf("Queue Overflow!\n");
+        return;
+    }
+    stack->data[++(stack->top)] = value;
+    stack->size++;
+}
+
+int dequeue(struct Stack *stack)
+{
+    if (stack->size == 0)
+    {
+        printf("Queue Underflow!\n");
+        return -1;
+    }
+
+    struct Stack *tempStack = (struct Stack *)malloc(sizeof(struct Stack));
+    tempStack->top = -1;
+    tempStack->size = 0;
+
+    while (stack->size > 1)
+    {
+        enqueue(tempStack, stack->data[stack->top--]);
+        stack->size--;
+    }
+
+    int dequeuedValue = stack->data[stack->top--];
+    stack->size--;
+
+    while (tempStack->size > 0)
+    {
+        enqueue(stack, tempStack->data[tempStack->top--]);
+        tempStack->size--;
+    }
+
+    free(tempStack);
+    return dequeuedValue;
+}
+
+int front(struct Stack *stack)
+{
+    if (stack->size == 0)
+    {
+        printf("Queue is empty.\n");
+        return -1;
+    }
+
+    struct Stack *tempStack = (struct Stack *)malloc(sizeof(struct Stack));
+    tempStack->size = 0;
+    tempStack->top = -1;
+
+    while (stack->size > 0)
+    {
+        enqueue(tempStack, stack->data[stack->top--]);
+        stack->size--;
+    }
+
+    int frontElement = tempStack->data[tempStack->top];
+
+    while (tempStack->size > 0)
+    {
+        enqueue(stack, tempStack->data[tempStack->top--]);
+        tempStack->size--;
+    }
+
+    free(tempStack);
+    return frontElement;
+}
+
+int isEmpty(struct Stack *stack)
+{
+    return stack->size == 0;
+}
+
+int main()
+{
+    struct Stack *stack = (struct Stack *)malloc(sizeof(struct Stack));
+    stack->top = -1;
+    stack->size = 0;
+
+    int choice, data;
+
+    printf("\nQueue Using One Stack (Iterative Dequeue)\n");
+    printf("1. Enqueue\n2. Dequeue\n3. Display Front\n4. Check Empty\n5. Exit\n");
+
+    while (1)
+    {
+        printf("\nEnter choice: ");
+        scanf("%d", &choice);
+
+        switch (choice)
+        {
+        case 1:
+            printf("Enter data: ");
+            scanf("%d", &data);
+            enqueue(stack, data);
+            break;
+        case 2:
+            data = dequeue(stack);
+            if (data != -1)
+                printf("Dequeued: %d\n", data);
+            break;
+        case 3:
+            data = front(stack);
+            if (data != -1)
+                printf("Front: %d\n", data);
+            break;
+        case 4:
+            printf(isEmpty(stack) ? "Queue is Empty\n" : "Queue is Not Empty\n");
+            break;
+        case 5:
+            free(stack);
+            printf("Exiting...\n");
+            return 0;
+        default:
+            printf("Invalid Choice!\n");
+        }
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
Queue Implementation Using Two Stacks
This method ensures a more efficient queue simulation using two stacks, one for pushing (input stack) and another for popping (output stack).

Enqueue (Push) → O(1): Inserts elements directly into stack1.
Dequeue (Pop) → O(n) (Worst Case): Transfers elements to stack2 only when it's empty. In amortized analysis, it’s O(1) for most operations.
Front → O(n) (Worst Case): Similar to dequeue, requires stack transfer.
IsEmpty → O(1): Simply checks sizes of both stacks.
This approach is more efficient than using one stack since it avoids continuous data reversal.